### PR TITLE
Adding a matching user inside container

### DIFF
--- a/r-dsci-100/Dockerfile
+++ b/r-dsci-100/Dockerfile
@@ -18,10 +18,10 @@ RUN Rscript -e "install.packages('infer', repos = 'http://cran.us.r-project.org'
 RUN Rscript -e "install.packages('scatterplot3d', repos = 'http://cran.us.r-project.org')"
 
 USER root
-RUN useradd -m -s /bin/bash -N -u 1002 dsci100
-USER dsci100
+RUN useradd -m -s /bin/bash -N -u 9999 jupyter
+USER jupyter
 # Configure environment
-ENV NB_USER=dsci100 \
-    NB_UID=1002
+ENV NB_USER=jupyter \
+    NB_UID=9999
 ENV HOME=/home/$NB_USER
 WORKDIR $HOME

--- a/r-dsci-100/Dockerfile
+++ b/r-dsci-100/Dockerfile
@@ -2,7 +2,9 @@
 # Distributed under the terms of the Modified BSD License.
 FROM jupyter/r-notebook
 
-USER root
+
+RUN pip install git+https://github.com/data-8/nbgitpuller \
+ && jupyter serverextension enable --sys-prefix nbgitpuller
 
 # R packages
 RUN conda install --quiet --yes \
@@ -12,5 +14,14 @@ RUN conda install --quiet --yes \
     conda clean -tipsy && \
     fix-permissions $CONDA_DIR
 
-RUN Rscript -e "install.packages('infer')"
+RUN Rscript -e "install.packages('infer', repos = 'http://cran.us.r-project.org')"
 RUN Rscript -e "install.packages('scatterplot3d', repos = 'http://cran.us.r-project.org')"
+
+USER root
+RUN useradd -m -s /bin/bash -N -u 1002 dsci100
+USER dsci100
+# Configure environment
+ENV NB_USER=dsci100 \
+    NB_UID=1002
+ENV HOME=/home/$NB_USER
+WORKDIR $HOME


### PR DESCRIPTION
This change adds nbgitpiller, specifies a repo for one of the R packages and
adds a user called dsci100 to use inside of the containers. The uid of the user
is selected to match that of the jupyter user in the infrastructure repository.

Signed-off-by: root <root@hub-prod-dsci.stat.ubc.ca>